### PR TITLE
perf: optimize CORS performance by caching preflight OPTIONS requests

### DIFF
--- a/source/source.js
+++ b/source/source.js
@@ -186,6 +186,11 @@ const sendResponse = (statusCode, bodyData) => {
             'Content-Type, Content-Encoding, Accept-Encoding, X-Gtm-Server-Preview, X-Keepalive-Request'
         );
         setResponseHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+
+        // Serve Access-Control-Max-Age on the preflight OPTIONS requests
+        if (getRequestMethod() === 'OPTIONS') {
+            setResponseHeader('Access-Control-Max-Age', '86400');
+        }
     }
     setResponseHeader('Content-Type', 'application/json;charset=UTF-8');
     setResponseStatus(statusCode || 200);

--- a/source/source.js
+++ b/source/source.js
@@ -33,6 +33,7 @@ const UA = getRequestHeader('user-agent');
 const HOST = getRequestHeader('host');
 
 const requestPath = getRequestPath();
+const requestMethod = getRequestMethod();
 
 const log = msg => {
     logToConsole('[JSON Client] ' + msg);
@@ -188,7 +189,7 @@ const sendResponse = (statusCode, bodyData) => {
         setResponseHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
 
         // Serve Access-Control-Max-Age on the preflight OPTIONS requests
-        if (getRequestMethod() === 'OPTIONS') {
+        if (requestMethod === 'OPTIONS') {
             setResponseHeader('Access-Control-Max-Age', '86400');
         }
     }
@@ -290,7 +291,6 @@ const runContainerForEventPromise = (event) => {
 };
 
 // handle the various request methods
-const requestMethod = getRequestMethod();
 if (requestMethod === 'POST') {
     const events = payloadToEvents(getRequestBody());
     if (events === null) {

--- a/template.tpl
+++ b/template.tpl
@@ -670,6 +670,7 @@ const UA = getRequestHeader('user-agent');
 const HOST = getRequestHeader('host');
 
 const requestPath = getRequestPath();
+const requestMethod = getRequestMethod();
 
 const log = msg => {
     logToConsole('[JSON Client] ' + msg);
@@ -825,7 +826,7 @@ const sendResponse = (statusCode, bodyData) => {
         setResponseHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
 
         // Serve Access-Control-Max-Age on the preflight OPTIONS requests
-        if (getRequestMethod() === 'OPTIONS') {
+        if (requestMethod === 'OPTIONS') {
             setResponseHeader('Access-Control-Max-Age', '86400');
         }
     }
@@ -927,7 +928,6 @@ const runContainerForEventPromise = (event) => {
 };
 
 // handle the various request methods
-const requestMethod = getRequestMethod();
 if (requestMethod === 'POST') {
     const events = payloadToEvents(getRequestBody());
     if (events === null) {

--- a/template.tpl
+++ b/template.tpl
@@ -823,6 +823,11 @@ const sendResponse = (statusCode, bodyData) => {
             'Content-Type, Content-Encoding, Accept-Encoding, X-Gtm-Server-Preview, X-Keepalive-Request'
         );
         setResponseHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+
+        // Serve Access-Control-Max-Age on the preflight OPTIONS requests
+        if (getRequestMethod() === 'OPTIONS') {
+            setResponseHeader('Access-Control-Max-Age', '86400');
+        }
     }
     setResponseHeader('Content-Type', 'application/json;charset=UTF-8');
     setResponseStatus(statusCode || 200);


### PR DESCRIPTION
### Summary
This PR adds the `Access-Control-Max-Age` header to preflight `OPTIONS` responses when CORS is enabled. It sets the cache duration to `86400` seconds (24 hours).

### Context & Motivation
Currently, cross-origin clients have to perform a preflight `OPTIONS` request before sending their actual tracking requests if the browser defaults to not caching the preflight or falls back to short default intervals (usually 5 seconds). By setting the `Access-Control-Max-Age` header, we allow client browsers to cache the authorized preflight results. This lowers response times for subsequent client events and decreases unnecessary incoming requests to the server.

### Browser Caching Behavior
Since browsers handle the maximum preflight cache duration differently, setting the limit to 24 hours (`86400` seconds) ensures we utilize the highest possible cache windows across the most common clients:
* **Firefox:** Caches the preflight response for the full configured **24 hours** (`86400` seconds).
* **Chromium (Chrome, Edge, Opera):** Clamps the cache duration to its internal maximum of **2 hours** (`7200` seconds).
* **Safari:** Clamps the cache duration to its internal maximum of **5 minutes** (`300` seconds).

### Changes
* Updated the `sendResponse` function to include `setResponseHeader('Access-Control-Max-Age', '86400')` specifically when handling preflight `OPTIONS` requests.

### Verification & Testing
* Enabled the `Enable CORS Headers` option in the JSON client in sGTM.
* Sent test `OPTIONS` requests to the sGTM container.
* Confirmed the `Access-Control-Max-Age` header is present in the response headers with the correct value when CORS is enabled.